### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/sapvs/perf-go/security/code-scanning/2](https://github.com/sapvs/perf-go/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will define the minimal permissions required for the workflow. Since the workflow only checks out code and runs tests, it likely only needs `contents: read` permission. This ensures that the `GITHUB_TOKEN` is restricted to read-only access to the repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
